### PR TITLE
fix:线程并发时，推送任务线程顺序错乱和任务状态不准确问题

### DIFF
--- a/src/main/java/com/github/novicezk/midjourney/ProxyProperties.java
+++ b/src/main/java/com/github/novicezk/midjourney/ProxyProperties.java
@@ -189,5 +189,9 @@ public class ProxyProperties {
 		 * 任务超时时间(分钟).
 		 */
 		private int timeoutMinutes = 5;
+		/**
+		 * 线程池CorePoolSize.
+		 */
+		private int poolSize = 10;
 	}
 }

--- a/src/main/java/com/github/novicezk/midjourney/ProxyProperties.java
+++ b/src/main/java/com/github/novicezk/midjourney/ProxyProperties.java
@@ -192,6 +192,6 @@ public class ProxyProperties {
 		/**
 		 * 线程池CorePoolSize.
 		 */
-		private int poolSize = 10;
+		private int notifyPoolSize = 10;
 	}
 }

--- a/src/main/java/com/github/novicezk/midjourney/service/NotifyServiceImpl.java
+++ b/src/main/java/com/github/novicezk/midjourney/service/NotifyServiceImpl.java
@@ -31,7 +31,7 @@ public class NotifyServiceImpl implements NotifyService {
 
 	public NotifyServiceImpl(ProxyProperties properties) {
 		this.executor = new ThreadPoolTaskExecutor();
-		this.executor.setCorePoolSize(properties.getQueue().getPoolSize());
+		this.executor.setCorePoolSize(properties.getQueue().getNotifyPoolSize());
 		this.executor.setThreadNamePrefix("TaskNotify-");
 		this.executor.initialize();
 	}

--- a/src/main/java/com/github/novicezk/midjourney/service/NotifyServiceImpl.java
+++ b/src/main/java/com/github/novicezk/midjourney/service/NotifyServiceImpl.java
@@ -5,6 +5,7 @@ import cn.hutool.core.text.CharSequenceUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.novicezk.midjourney.Constants;
+import com.github.novicezk.midjourney.ProxyProperties;
 import com.github.novicezk.midjourney.enums.TaskStatus;
 import com.github.novicezk.midjourney.support.Task;
 import lombok.extern.slf4j.Slf4j;
@@ -28,9 +29,9 @@ public class NotifyServiceImpl implements NotifyService {
 	private final ThreadPoolTaskExecutor executor;
 	private final Map<String, Object> taskLocks = new ConcurrentHashMap<>();
 
-	public NotifyServiceImpl() {
+	public NotifyServiceImpl(ProxyProperties properties) {
 		this.executor = new ThreadPoolTaskExecutor();
-		this.executor.setCorePoolSize(10);
+		this.executor.setCorePoolSize(properties.getQueue().getPoolSize());
 		this.executor.setThreadNamePrefix("TaskNotify-");
 		this.executor.initialize();
 	}

--- a/src/main/java/com/github/novicezk/midjourney/service/NotifyServiceImpl.java
+++ b/src/main/java/com/github/novicezk/midjourney/service/NotifyServiceImpl.java
@@ -1,10 +1,17 @@
 package com.github.novicezk.midjourney.service;
 
 import cn.hutool.core.text.CharSequenceUtil;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.novicezk.midjourney.Constants;
+import com.github.novicezk.midjourney.enums.TaskStatus;
 import com.github.novicezk.midjourney.support.Task;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -19,6 +26,7 @@ import org.springframework.web.client.RestTemplate;
 public class NotifyServiceImpl implements NotifyService {
 	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 	private final ThreadPoolTaskExecutor executor;
+	private final Map<String, Object> taskLocks = new ConcurrentHashMap<>();
 
 	public NotifyServiceImpl() {
 		this.executor = new ThreadPoolTaskExecutor();
@@ -33,19 +41,32 @@ public class NotifyServiceImpl implements NotifyService {
 		if (CharSequenceUtil.isBlank(notifyHook)) {
 			return;
 		}
-		this.executor.execute(() -> {
-			try {
-				String paramsStr = OBJECT_MAPPER.writeValueAsString(task);
-				ResponseEntity<String> responseEntity = postJson(notifyHook, paramsStr);
-				if (responseEntity.getStatusCode() == HttpStatus.OK) {
-					log.debug("推送任务变更成功, 任务ID: {}, status: {}", task.getId(), task.getStatus());
-				} else {
-					log.warn("推送任务变更失败, 任务ID: {}, code: {}, msg: {}", task.getId(), responseEntity.getStatusCodeValue(), responseEntity.getBody());
+		// 获取线程所需的参数，避免在线程中获取
+		String tastId = task.getId();
+		TaskStatus taskStatus = task.getStatus();
+		Object taskLock = taskLocks.computeIfAbsent(tastId, id -> new Object()); // 获取任务对应的锁对象，避免同一任务id进度推送顺序错乱问题
+		log.debug("创建任务变更线程, 任务ID: {}, status: {}", tastId, taskStatus);
+		try {
+			String paramsStr = OBJECT_MAPPER.writeValueAsString(task);
+			this.executor.execute(() -> {
+				synchronized (taskLock) {
+					try {
+						log.debug("开始推送任务变更, 任务ID: {}, status: {}", tastId, taskStatus);
+						ResponseEntity<String> responseEntity = postJson(notifyHook, paramsStr);
+						if (responseEntity.getStatusCode() == HttpStatus.OK) {
+							log.debug("推送任务变更成功, 任务ID: {}, status: {}", tastId, taskStatus);
+						} else {
+							log.warn("推送任务变更失败, 任务ID: {}, code: {}, msg: {}", tastId, responseEntity.getStatusCodeValue(), responseEntity.getBody());
+						}
+					} catch (Exception e) {
+						log.warn("推送任务变更失败, 任务ID: {}, 描述: {}", tastId, e.getMessage());
+					}
 				}
-			} catch (Exception e) {
-				log.warn("推送任务变更失败, 任务ID: {}, 描述: {}", task.getId(), e.getMessage());
-			}
-		});
+			});
+		} catch (JsonProcessingException e) {
+			log.warn("创建任务ID: {}, status: {}, 描述: {}", tastId, taskStatus, e.getMessage());
+		}
+		
 	}
 
 	private ResponseEntity<String> postJson(String notifyHook, String paramsJson) {


### PR DESCRIPTION
大量并发时会导致线程拥堵，导致2个问题：
1.线程处理不及时，可能会被后续的线程修改当前线程中的任务状态，导致不合预期，例如当IN_PROGRESS状态的线程阻塞时，可能会被最终的SUCCESS状态覆盖，造成通知时变成多条SUCCESS状态推送。在创建线程之前获取状态值，可以避免这个问题。
2.线程的处理顺序随机性较强，无法保证按照顺序执行，可能出现推送完SUCCESS后仍然有IN_PROGRESS任务状态推送，或progress数值先后顺序错乱，按照任务ID增加线程锁可以保证同一个任务的状态时顺序通知。