### PR TITLE
fix:排队时，队列数量提示错误

### DIFF
--- a/src/main/java/com/github/novicezk/midjourney/controller/SubmitController.java
+++ b/src/main/java/com/github/novicezk/midjourney/controller/SubmitController.java
@@ -70,6 +70,9 @@ public class SubmitController {
 		if (CharSequenceUtil.isBlank(promptEn)) {
 			promptEn = prompt;
 		}
+		promptEn = promptEn.replaceAll("\\s+", " ") // MJ会自动缩减连续的空格
+        .replaceAll(" —", " --")    // MJ兼容" —"作为参数提示符，但是返回时会自动修正为" --"
+        .trim();
 		if (BannedPromptUtils.isBanned(promptEn)) {
 			return SubmitResultVO.fail(ReturnCode.BANNED_PROMPT, "可能包含敏感词");
 		}

--- a/src/main/java/com/github/novicezk/midjourney/support/TaskQueueHelper.java
+++ b/src/main/java/com/github/novicezk/midjourney/support/TaskQueueHelper.java
@@ -71,8 +71,8 @@ public class TaskQueueHelper {
 		this.taskStoreService.save(task);
 		int size;
 		try {
-			size = this.taskExecutor.getThreadPoolExecutor().getQueue().size();
 			Future<?> future = this.taskExecutor.submit(() -> executeTask(task, discordSubmit));
+			size = this.taskExecutor.getThreadPoolExecutor().getQueue().size();
 			this.taskFutureMap.put(task.getId(), future);
 		} catch (RejectedExecutionException e) {
 			this.taskStoreService.delete(task.getId());


### PR DESCRIPTION
目前设置了任务队列数量为3，提交第4个任务时候并不会提示开始排队，提交第5个任务时候会开始排队计数，且返回前面任务为1个。
应当在this.taskExecutor.submit执行之后再检查队列中的任务数量获取getQueue().size()，这样避免排队数量统计遗漏的错误。
修改后的结果为：设置了任务队列数量为3时，提交第4个任务时候提示还有1个任务等待，提交第5个任务时候提示前面任务为2个。