### PR TITLE
fix: 翻译的内容没有排除 image prompt，有时会报百度翻译签名失败

### DIFF
--- a/src/main/java/com/github/novicezk/midjourney/controller/SubmitController.java
+++ b/src/main/java/com/github/novicezk/midjourney/controller/SubmitController.java
@@ -41,6 +41,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Api(tags = "任务提交")
 @RestController
@@ -213,16 +215,25 @@ public class SubmitController {
 	}
 
 	private String translatePrompt(String prompt) {
-		String promptEn;
-		int paramStart = prompt.indexOf(" --");
-		if (paramStart > 0) {
-			promptEn = this.translateService.translateToEnglish(prompt.substring(0, paramStart)).trim() + prompt.substring(paramStart);
-		} else {
-			promptEn = this.translateService.translateToEnglish(prompt).trim();
+        String image = "";
+        Matcher imageMatcher = Pattern.compile("^https?://[a-z0-9-_:@&?=+,.!/~*'%$]{1,}\\x20{1,}", Pattern.CASE_INSENSITIVE).matcher(prompt);
+        if (imageMatcher.find()) {
+            image = imageMatcher.group(0);
+        }
+
+        String param = "";
+        Matcher paramMatcher = Pattern.compile("\\x20{1,}-{1,2}.*$", Pattern.CASE_INSENSITIVE).matcher(prompt);
+        if (paramMatcher.find()) {
+            param = paramMatcher.group(0);
+        }
+
+        String textPrompt = prompt.substring(image.length(), prompt.length() - param.length());
+
+		String textPromptEn = this.translateService.translateToEnglish(textPrompt).trim();
+		if (CharSequenceUtil.isBlank(textPromptEn)) {
+			textPromptEn = prompt;
 		}
-		if (CharSequenceUtil.isBlank(promptEn)) {
-			promptEn = prompt;
-		}
-		return promptEn;
+		
+		return image + textPromptEn + param;
 	}
 }


### PR DESCRIPTION
测试可以重现

URL: /mj/submit/imagine

{
  "base64Array": [],
  "notifyHook": "",
  "prompt": "https://cdn.discordapp.com/attachments/1130758390105260083/1156098358356742194/1695705725054582.png?ex=6513bbff&is=65126a7f&hm=a9d9fdbbea9bc0aeba5bf278765d32752b27ed3c3e8a0970165875ef56b673fb& 一个美丽的中国仙女式女孩，仙气十足，甜美迷人的笑容，漂亮的脸蛋，精致的脸部，渐变色块拼接成画面，动感的表现力，柔和的色彩，柔和、大胆、飘逸，工笔画，吴贯中风格，超高清，背景空中漂浮着许愿灯。 --niji 5 --stylize 500 --quality 1 --aspect 9:16 --iw 1.25",
  "state": ""
}
