### PR TITLE
fix(imagine): update the imagine api version

### DIFF
--- a/src/main/resources/api-params/imagine.json
+++ b/src/main/resources/api-params/imagine.json
@@ -6,7 +6,7 @@
   "session_id": "$session_id",
   "nonce": "$nonce",
   "data": {
-    "version": "1166847114203123795",
+    "version": "1237876415471554623",
     "id": "938956540159881230",
     "name": "imagine",
     "type": 1,


### PR DESCRIPTION
更新了imagine的版本号，与imagine的mj接口保持一致，解决旧版本号请求失败问题