### PR TITLE
feat: add aliyun oss storage config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -32,6 +32,7 @@
 | mj.openai.max-tokens          | 否  | 返回结果的最大分词数，默认2048                             |
 | mj.openai.temperature         | 否  | 相似度(0-2.0)，默认0                                |
 | spring.redis                  | 否  | 任务存储方式设置为redis，需配置redis相关属性                   |
+| oss.config | 否 | 将图片上传至阿里云oss存储桶，存储桶访问凭证配置 |
 
 ### 账号池配置参考
 ```yaml
@@ -68,3 +69,32 @@ spring:
     port: 6379
     password: xxx
 ```
+
+### 阿里云oss配置参考
+
+```
+oss:
+  config:
+    oss-save: false
+    access-key-id: LTAI5tAzZJnSy3P8t75dGCc
+    access-key-secret: Hmjs1mNo9qBe3E0TIyY2nsPoD0o5hc
+    endpoint: https://oss-cn-hangzhou.aliyuncs.com
+    bucket-name: midjoureny-images
+    to-sign: true
+    prefix-path: mj
+    expiration-seconds: 3600
+```
+
+账号字段说明
+
+| 名称               | 非空 | 描述                                                         |
+| :----------------- | :--: | :----------------------------------------------------------- |
+| oss-save           |  否  | 是否保存到阿里云oss，默认false                               |
+| access-key-id      |  是  | 阿里云存储 AccessKeyID                                       |
+| access-key-secret  |  是  | 阿里云存储 AccessKeySecret                                   |
+| endpoint           |  是  | 阿里云oss节点地址                                            |
+| bucket-name        |  是  | 存储桶名称                                                   |
+| to-sign            |  否  | 是否使用预签名图片地址，默认false                            |
+| prefix-path        |  否  | 存储路径                                                     |
+| expiration-seconds |  否  | 签名oss图片地址的过期时间，默认3000秒,当使用预签名图片地址时生效 |
+

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.aliyun.oss</groupId>
+            <artifactId>aliyun-sdk-oss</artifactId>
+            <version>3.17.4</version>
+        </dependency>
+        <dependency>
             <groupId>eu.maxschuster</groupId>
             <artifactId>dataurl</artifactId>
             <version>${dataurl.version}</version>

--- a/src/main/java/com/github/novicezk/midjourney/OssProperties.java
+++ b/src/main/java/com/github/novicezk/midjourney/OssProperties.java
@@ -1,0 +1,43 @@
+package com.github.novicezk.midjourney;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import lombok.Data;
+
+@Component
+@ConfigurationProperties(prefix = "oss.config")
+@Data
+public class OssProperties {
+    /**
+     * 访问KEY ID.
+     */
+    private String accessKeyId;
+    /**
+     * 访问KEY密钥.
+     */
+    private String accessKeySecret;
+    /**
+     * 节点地址.
+     */
+    private String endpoint;
+    /**
+     * 存储桶名称.
+     */
+    private String bucketName;
+    /**
+     * 存储文件夹路径.
+     */
+    private String prefixPath;
+    /**
+     * 是否使用上传至阿里云oss存储.
+     */
+    private Boolean ossSave = false;
+    /**
+     * 是否使用签名URL.
+     */
+    private Boolean toSign = false;
+    /**
+     * 预签名访问链接过期时间，默认过期时间3000秒
+     */
+    private Integer expirationSeconds = 3000;
+}

--- a/src/main/java/com/github/novicezk/midjourney/OssProperties.java
+++ b/src/main/java/com/github/novicezk/midjourney/OssProperties.java
@@ -44,4 +44,9 @@ public class OssProperties {
      * 是否使用自定义cdn加速域名
      */
     private Boolean isCname = false;
+
+    /**
+     * 自定义cdn加速域名地址.
+     */
+    private String cdnEndpoint;
 }

--- a/src/main/java/com/github/novicezk/midjourney/OssProperties.java
+++ b/src/main/java/com/github/novicezk/midjourney/OssProperties.java
@@ -40,4 +40,8 @@ public class OssProperties {
      * 预签名访问链接过期时间，默认过期时间3000秒
      */
     private Integer expirationSeconds = 3000;
+    /**
+     * 是否使用自定义cdn加速域名
+     */
+    private Boolean isCname = false;
 }

--- a/src/main/java/com/github/novicezk/midjourney/support/Task.java
+++ b/src/main/java/com/github/novicezk/midjourney/support/Task.java
@@ -41,6 +41,8 @@ public class Task extends DomainObject {
 
 	@ApiModelProperty("图片url")
 	private String imageUrl;
+	@ApiModelProperty("oss图片url")
+	private String ossImageUrl;
 
 	@ApiModelProperty("任务进度")
 	private String progress;

--- a/src/main/java/com/github/novicezk/midjourney/wss/handle/ExtImageSaveHandler.java
+++ b/src/main/java/com/github/novicezk/midjourney/wss/handle/ExtImageSaveHandler.java
@@ -1,0 +1,103 @@
+package com.github.novicezk.midjourney.wss.handle;
+
+import com.aliyun.oss.OSS;
+import com.aliyun.oss.OSSClientBuilder;
+import com.aliyun.oss.model.GeneratePresignedUrlRequest;
+import com.aliyun.oss.model.PutObjectRequest;
+import com.github.novicezk.midjourney.OssProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class ExtImageSaveHandler {
+
+    private final OssProperties ossProperties;
+    private final OSS ossClient;
+
+    @Autowired
+    public ExtImageSaveHandler(OssProperties ossProperties) {
+        this.ossProperties = ossProperties;
+        this.ossClient = createOssClient();
+    }
+
+    public String uploadToOSSAndGetUrl(String imageUrl) {
+        String bucketName = ossProperties.getBucketName();
+        if (!ossProperties.getOssSave() || bucketName == null){
+            return null;
+        }
+        File file = downloadImage(imageUrl);
+        if (file != null && file.exists()) {
+            String objectKey = ossProperties.getPrefixPath() + "/" + UUID.randomUUID() + getFileExtension(imageUrl);
+            PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, objectKey, file);
+            ossClient.putObject(putObjectRequest);
+
+            if (ossProperties.getToSign()) {
+                GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                        new GeneratePresignedUrlRequest(bucketName, objectKey);
+                generatePresignedUrlRequest.setExpiration(new Date(System.currentTimeMillis() + ossProperties.getExpirationSeconds() * 1000));
+                URL url = ossClient.generatePresignedUrl(generatePresignedUrlRequest);
+                return url.toString();
+            } else {
+                String endpoint = ossProperties.getEndpoint().split("https://")[1];
+                return "https://" + bucketName + "." + endpoint + "/" + objectKey;
+            }
+        }
+        return null;
+    }
+
+    private OSS createOssClient() {
+        return new OSSClientBuilder().build(
+                ossProperties.getEndpoint(),
+                ossProperties.getAccessKeyId(),
+                ossProperties.getAccessKeySecret()
+        );
+    }
+
+    private static File downloadImage(String imageUrl) {
+        try {
+            URI uri = new URI(imageUrl);
+            URL url = uri.toURL();
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
+            connection.connect();
+
+            int responseCode = connection.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_OK) {
+                InputStream inputStream = connection.getInputStream();
+                File file = File.createTempFile("tempImage", "tmp");
+                file.deleteOnExit();
+
+                try (FileOutputStream outputStream = new FileOutputStream(file)) {
+                    byte[] buffer = new byte[4096];
+                    int bytesRead;
+                    while ((bytesRead = inputStream.read(buffer)) != -1) {
+                        outputStream.write(buffer, 0, bytesRead);
+                    }
+                }
+                return file;
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+        return null;
+    }
+
+    private static String getFileExtension(String imageUrl) {
+        String fileName = new File(imageUrl.split("\\?")[0]).getName();
+        int dotIndex = fileName.lastIndexOf('.');
+        return dotIndex > 0 ? fileName.substring(dotIndex) : "";
+    }
+}

--- a/src/main/java/com/github/novicezk/midjourney/wss/handle/ExtImageSaveHandler.java
+++ b/src/main/java/com/github/novicezk/midjourney/wss/handle/ExtImageSaveHandler.java
@@ -1,5 +1,4 @@
 package com.github.novicezk.midjourney.wss.handle;
-
 import com.aliyun.oss.ClientBuilderConfiguration;
 import com.aliyun.oss.OSS;
 import com.aliyun.oss.OSSClientBuilder;
@@ -8,7 +7,7 @@ import com.aliyun.oss.model.PutObjectRequest;
 import com.github.novicezk.midjourney.OssProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
+import lombok.extern.slf4j.Slf4j;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -20,6 +19,7 @@ import java.net.URL;
 import java.util.Date;
 import java.util.UUID;
 
+@Slf4j
 @Component
 public class ExtImageSaveHandler {
 
@@ -38,56 +38,66 @@ public class ExtImageSaveHandler {
             return null;
         }
         File file = null;
-        try {
-            file = downloadImage(imageUrl);
-            if (file != null && file.exists()) {
-                String objectKey = ossProperties.getPrefixPath() + "/" + UUID.randomUUID() + getFileExtension(imageUrl);
-                PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, objectKey, file);
-                ossClient.putObject(putObjectRequest);
+        int maxRetries = 3;
+        int retries = 0;
+        String url = null;
 
-                if (ossProperties.getToSign()) {
-                    GeneratePresignedUrlRequest generatePresignedUrlRequest =
-                            new GeneratePresignedUrlRequest(bucketName, objectKey);
-                    generatePresignedUrlRequest.setExpiration(new Date(System.currentTimeMillis() + ossProperties.getExpirationSeconds() * 1000));
-                    URL url = ossClient.generatePresignedUrl(generatePresignedUrlRequest);
+        while (retries < maxRetries) {
+            try {
+                file = downloadImage(imageUrl, maxRetries);
+                if (file != null && file.exists()) {
+                    log.debug("Image downloaded successfully. Start upload file to oss");
+                    String objectKey = ossProperties.getPrefixPath() + "/" + UUID.randomUUID() + getFileExtension(imageUrl);
+                    PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, objectKey, file);
+                    ossClient.putObject(putObjectRequest);
 
-                    return url.toString();
-                } else {
-                    String protocol = "https://";
-                    String endpoint = ossProperties.getEndpoint();
-
-                    if (endpoint.contains("://")) {
-                        String[] parts = endpoint.split("://", 2);
-                        protocol = parts[0] + "://";
-                        endpoint = parts[1];
-                    }
-
-                    String fileUrl;
-                    if (ossProperties.getIsCname()) {
-                        fileUrl = protocol + endpoint + "/" + objectKey;
+                    if (ossProperties.getToSign()) {
+                        GeneratePresignedUrlRequest generatePresignedUrlRequest =
+                                new GeneratePresignedUrlRequest(bucketName, objectKey);
+                        generatePresignedUrlRequest.setExpiration(new Date(System.currentTimeMillis() + ossProperties.getExpirationSeconds() * 1000));
+                        URL generatedUrl = ossClient.generatePresignedUrl(generatePresignedUrlRequest);
+                        url = generatedUrl.toString();
                     } else {
-                        fileUrl = protocol + bucketName + "." + endpoint + "/" + objectKey;
-
+                        String protocol = "https://";
+                        String endpoint = ossProperties.getEndpoint();
+                        if (endpoint.contains("://")) {
+                            String[] parts = endpoint.split("://", 2);
+                            protocol = parts[0] + "://";
+                            endpoint = parts[1];
+                        }
+                        String fileUrl;
+                        if (ossProperties.getIsCname()) {
+                            fileUrl = protocol + endpoint + "/" + objectKey;
+                        } else {
+                            fileUrl = protocol + bucketName + "." + endpoint + "/" + objectKey;
+                        }
+                        url = fileUrl;
                     }
-                    return fileUrl;
+                    break;
                 }
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        } finally {
-            if (file != null) {
-                boolean deleted = file.delete();
-                if (!deleted) {
-                    System.err.println("Failed to delete the temporary file: " + file.getAbsolutePath());
+            } catch (Exception e) {
+                log.error("Failed to upload image to aliyun oss. Retrying... ", e);
+                retries++;
+                if (retries >= maxRetries) {
+                    log.error("Failed to upload image to aliyun oss after {} attempts.", maxRetries);
+                }
+            } finally {
+                if (file != null) {
+                    boolean deleted = file.delete();
+                    if (!deleted) {
+                        log.error("Failed to delete the temporary file: " + file.getAbsolutePath());
+                    }
                 }
             }
         }
-        return null;
+        return url;
     }
 
     private OSS createOssClient() {
         ClientBuilderConfiguration config = new ClientBuilderConfiguration();
         config.setSupportCname(ossProperties.getIsCname());
+        config.setConnectionTimeout(10000);
+        config.setSocketTimeout(30000);
         return new OSSClientBuilder().build(
                 ossProperties.getEndpoint(),
                 ossProperties.getAccessKeyId(),
@@ -96,34 +106,53 @@ public class ExtImageSaveHandler {
         );
     }
 
-    private static File downloadImage(String imageUrl) {
-        try {
-            URI uri = new URI(imageUrl);
-            URL url = uri.toURL();
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-            connection.setRequestMethod("GET");
-            connection.connect();
+    private static File downloadImage(String imageUrl, int maxRetries) {
+        int retries = 0;
+        while (retries < maxRetries) {
+            try {
+                URI uri = new URI(imageUrl);
+                URL url = uri.toURL();
+                HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+                connection.setRequestMethod("GET");
+                connection.setConnectTimeout(10000);
+                connection.setReadTimeout(10000);
+                connection.connect();
 
-            int responseCode = connection.getResponseCode();
-            if (responseCode == HttpURLConnection.HTTP_OK) {
-                InputStream inputStream = connection.getInputStream();
-                File file = File.createTempFile("tempImage", "tmp");
-                file.deleteOnExit();
+                int responseCode = connection.getResponseCode();
+                if (responseCode == HttpURLConnection.HTTP_OK) {
+                    InputStream inputStream = connection.getInputStream();
+                    File file = File.createTempFile("tempImage", "tmp");
+                    file.deleteOnExit();
 
-                try (FileOutputStream outputStream = new FileOutputStream(file)) {
-                    byte[] buffer = new byte[4096];
-                    int bytesRead;
-                    while ((bytesRead = inputStream.read(buffer)) != -1) {
-                        outputStream.write(buffer, 0, bytesRead);
+                    try (FileOutputStream outputStream = new FileOutputStream(file)) {
+                        byte[] buffer = new byte[4096];
+                        int bytesRead;
+                        while ((bytesRead = inputStream.read(buffer)) != -1) {
+                            outputStream.write(buffer, 0, bytesRead);
+                        }
                     }
+                    return file;
+                } else {
+                    log.warn("Failed to download image, HTTP response code: " + responseCode);
                 }
-                return file;
+            } catch (IOException e) {
+                log.warn("IOException occurred, retrying... " + e.getMessage());
+                e.printStackTrace();
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            } finally {
+                try {
+                    if (retries < maxRetries - 1) {
+                        Thread.sleep(1000);
+                    }
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    log.warn("Thread was interrupted");
+                }
             }
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
+            retries++;
         }
+        log.error("Failed to download image after several attempts.");
         return null;
     }
 

--- a/src/main/java/com/github/novicezk/midjourney/wss/handle/ExtImageSaveHandler.java
+++ b/src/main/java/com/github/novicezk/midjourney/wss/handle/ExtImageSaveHandler.java
@@ -59,19 +59,13 @@ public class ExtImageSaveHandler {
                         url = generatedUrl.toString();
                     } else {
                         String protocol = "https://";
-                        String endpoint = ossProperties.getEndpoint();
+                        String endpoint = ossProperties.getIsCname() ? ossProperties.getCdnEndpoint() : ossProperties.getEndpoint();
                         if (endpoint.contains("://")) {
                             String[] parts = endpoint.split("://", 2);
                             protocol = parts[0] + "://";
                             endpoint = parts[1];
                         }
-                        String fileUrl;
-                        if (ossProperties.getIsCname()) {
-                            fileUrl = protocol + endpoint + "/" + objectKey;
-                        } else {
-                            fileUrl = protocol + bucketName + "." + endpoint + "/" + objectKey;
-                        }
-                        url = fileUrl;
+                        url = protocol + (ossProperties.getIsCname() ? endpoint : bucketName + "." + endpoint) + "/" + objectKey;
                     }
                     break;
                 }

--- a/src/main/java/com/github/novicezk/midjourney/wss/handle/MessageHandler.java
+++ b/src/main/java/com/github/novicezk/midjourney/wss/handle/MessageHandler.java
@@ -2,6 +2,7 @@ package com.github.novicezk.midjourney.wss.handle;
 
 import cn.hutool.core.text.CharSequenceUtil;
 import com.github.novicezk.midjourney.Constants;
+import com.github.novicezk.midjourney.OssProperties;
 import com.github.novicezk.midjourney.enums.MessageType;
 import com.github.novicezk.midjourney.enums.TaskAction;
 import com.github.novicezk.midjourney.enums.TaskStatus;
@@ -13,6 +14,8 @@ import com.github.novicezk.midjourney.support.TaskCondition;
 import com.github.novicezk.midjourney.util.ConvertUtils;
 import net.dv8tion.jda.api.utils.data.DataArray;
 import net.dv8tion.jda.api.utils.data.DataObject;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.StringUtils;
 
 import javax.annotation.Resource;
 import java.util.Comparator;
@@ -24,6 +27,10 @@ public abstract class MessageHandler {
 	protected DiscordLoadBalancer discordLoadBalancer;
 	@Resource
 	protected DiscordHelper discordHelper;
+
+	@Autowired
+	protected ExtImageSaveHandler extImageSaveHandler;
+
 
 	public abstract void handle(DiscordInstance instance, MessageType messageType, DataObject message);
 
@@ -76,6 +83,10 @@ public abstract class MessageHandler {
 		task.setProperty(Constants.TASK_PROPERTY_FINAL_PROMPT, finalPrompt);
 		task.setProperty(Constants.TASK_PROPERTY_MESSAGE_HASH, messageHash);
 		task.setImageUrl(imageUrl);
+		if (StringUtils.hasText(imageUrl) && !StringUtils.hasText(task.getOssImageUrl())) {
+			task.setOssImageUrl(extImageSaveHandler.uploadToOSSAndGetUrl(imageUrl));
+		}
+
 		finishTask(task, message);
 		task.awake();
 	}

--- a/src/main/java/com/github/novicezk/midjourney/wss/handle/MessageHandler.java
+++ b/src/main/java/com/github/novicezk/midjourney/wss/handle/MessageHandler.java
@@ -32,6 +32,11 @@ public abstract class MessageHandler {
 	public abstract void handle(DiscordInstance instance, MessageType messageType, DataObject message);
 
 
+	public int order() {
+		return 100;
+	}
+
+
 	protected String getMessageContent(DataObject message) {
 		return message.hasKey("content") ? message.getString("content") : "";
 	}

--- a/src/main/java/com/github/novicezk/midjourney/wss/handle/UpscaleSuccessHandler.java
+++ b/src/main/java/com/github/novicezk/midjourney/wss/handle/UpscaleSuccessHandler.java
@@ -12,7 +12,9 @@ import com.github.novicezk.midjourney.util.ContentParseData;
 import com.github.novicezk.midjourney.util.ConvertUtils;
 import lombok.Data;
 import net.dv8tion.jda.api.utils.data.DataObject;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.util.Comparator;
 import java.util.Set;
@@ -68,6 +70,9 @@ public class UpscaleSuccessHandler extends MessageHandler {
 		task.setProperty(Constants.TASK_PROPERTY_FINAL_PROMPT, finalPrompt);
 		task.setProperty(Constants.TASK_PROPERTY_MESSAGE_HASH, messageHash);
 		task.setImageUrl(imageUrl);
+		if (StringUtils.hasText(imageUrl) && !StringUtils.hasText(task.getOssImageUrl())) {
+			task.setOssImageUrl(extImageSaveHandler.uploadToOSSAndGetUrl(imageUrl));
+		}
 		finishTask(task, message);
 		task.awake();
 	}


### PR DESCRIPTION
新增`oss图片地址`返回字段，任务完成后上传图片到阿里云oss存储，返回云端oss图片地址
```
oss:
  config:
    oss-save: false
    access-key-id: LTAI5tAzZJnSy3P8t75dGCc
    access-key-secret: Hmjs1mNo9qBe3E0TIyY2nsPoD0o5hc
    endpoint: https://oss-cn-hangzhou.aliyuncs.com
    bucket-name: midjoureny-images
    to-sign: true
    prefix-path: mj
    expiration-seconds: 3600
```
账号字段说明

| 名称               | 非空 | 描述                                                         |
| :----------------- | :--: | :----------------------------------------------------------- |
| oss-save           |  否  | 是否保存到阿里云oss，默认false                               |
| access-key-id      |  是  | 阿里云存储 AccessKeyID                                       |
| access-key-secret  |  是  | 阿里云存储 AccessKeySecret                                   |
| endpoint           |  是  | 阿里云oss节点地址                                            |
| bucket-name        |  是  | 存储桶名称                                                   |
| to-sign            |  否  | 是否使用预签名图片地址，默认false                            |
| prefix-path        |  否  | 存储路径                                                     |
| expiration-seconds |  否  | 签名oss图片地址的过期时间，默认3000秒,当使用预签名图片地址时生效 |





